### PR TITLE
HeaderListView crash fixed:

### DIFF
--- a/HeaderListView/src/main/java/com/applidium/headerlistview/SectionAdapter.java
+++ b/HeaderListView/src/main/java/com/applidium/headerlistview/SectionAdapter.java
@@ -168,14 +168,14 @@ public abstract class SectionAdapter extends BaseAdapter implements OnItemClickL
 
     @Override
     public void notifyDataSetChanged() {
-        super.notifyDataSetChanged();
         mCount = numberOfCellsBeforeSection(numberOfSections());
+        super.notifyDataSetChanged();
     }
 
     @Override
     public void notifyDataSetInvalidated() {
-        super.notifyDataSetInvalidated();
         mCount = numberOfCellsBeforeSection(numberOfSections());
+        super.notifyDataSetInvalidated();
     }
 
     @Override


### PR DESCRIPTION
Crash scenario:
- scroll list view
- call notifyDataSetChanged() on SectionAdapter while scrolling
- make sure, that count of items would differ after refresh

Result:
Crash occurs with stacktrace (Android 4.4.2):
java.lang.IllegalStateException: The content of the adapter has changed but ListView did not receive a notification. Make sure the content of your adapter is not modified from a background thread, but only from the UI thread. Make sure your adapter calls notifyDataSetChanged() when its content changes. [in ListView(-1, class com.applidium.headerlistview.HeaderListView$InternalListView) with Adapter(class android.widget.HeaderViewListAdapter)]
            at android.widget.ListView.layoutChildren(ListView.java:1555)
            at android.widget.AbsListView$FlingRunnable.run(AbsListView.java:4202)
            at android.view.Choreographer$CallbackRecord.run(Choreographer.java:761)
            at android.view.Choreographer.doCallbacks(Choreographer.java:574)
            at android.view.Choreographer.doFrame(Choreographer.java:543)
            at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:747)
            at android.os.Handler.handleCallback(Handler.java:733)
            at android.os.Handler.dispatchMessage(Handler.java:95)
            at android.os.Looper.loop(Looper.java:136)
            at android.app.ActivityThread.main(ActivityThread.java:5017)
            at java.lang.reflect.Method.invokeNative(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:515)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:779)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:595)
            at dalvik.system.NativeStart.main(Native Method)
